### PR TITLE
Use `ENTRYPOINT` for all beats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 venv
 build/*/Dockerfile
 build/*/config/*.sh
+build/*/docker-entrypoint
 docker-compose.yml
 .cache
 **/__pycache__

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,11 @@ $(BEATS):
 	  -D url=$(DOWNLOAD_URL_ROOT)/$@/$@-$(ELASTIC_VERSION)-linux-x86_64.tar.gz \
 	  -D dashboards_url=$(DOWNLOAD_URL_ROOT)/beats-dashboards/beats-dashboards-$(ELASTIC_VERSION).zip \
           templates/Dockerfile.j2 > build/$@/Dockerfile
+	jinja2 \
+	  -D beat=$@ \
+	  templates/docker-entrypoint.j2 > build/$@/docker-entrypoint
+	chmod +x build/$@/docker-entrypoint
+
 	docker build --tag=$(REGISTRY)/beats/$@:$(VERSION_TAG) build/$@
 
 push: all
@@ -68,6 +73,6 @@ venv: requirements.txt
 
 clean: venv
 	docker-compose down -v || true
-	rm -f docker-compose.yml build/*/Dockerfile build/*/config/*.sh
+	rm -f docker-compose.yml build/*/Dockerfile build/*/config/*.sh build/*/docker-entrypoint
 	rm -rf venv
 	find . -name __pycache__ | xargs rm -rf

--- a/templates/Dockerfile.j2
+++ b/templates/Dockerfile.j2
@@ -18,6 +18,9 @@ ENV PATH={{ beat_home }}:$PATH
 
 COPY config/{{ beat }}.yml {{ config_file }}
 
+# Add entrypoint wrapper script
+ADD docker-entrypoint /usr/local/bin
+
 # Provide a non-root user.
 RUN groupadd --gid 1000 {{ beat }} && \
     useradd -M --uid 1000 --gid 1000 --home {{ beat_home }} {{ beat }}
@@ -38,4 +41,5 @@ RUN setcap cap_net_raw=eip {{ binary_file }}
 {% endif %}
 USER {{ beat }}
 
-CMD ["{{ beat }}", "-e"]
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]
+CMD ["-e"]

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -16,7 +16,7 @@ services:
     cap_add:
       - NET_RAW
       - NET_ADMIN
-    command: packetbeat -v -e -E output.elasticsearch.hosts='["localhost:9200"]'
+    command: -v -e -E output.elasticsearch.hosts='["localhost:9200"]'
     network_mode: host
     {%- else %}
     networks:
@@ -29,7 +29,7 @@ services:
       - /proc:/hostfs/proc:ro
       - /sys/fs/cgroup:/hostfs/sys/fs/cgroup:ro
       - /:/hostfs:ro
-    command: metricbeat -e -system.hostfs=/hostfs
+    command: -e -system.hostfs=/hostfs
     {%- endif %}
     depends_on:
       elasticsearch:

--- a/templates/docker-entrypoint.j2
+++ b/templates/docker-entrypoint.j2
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+if [[ -z $1 ]] || [[ ${1:0:1} == '-' ]] ; then
+  exec {{ beat }} "$@"
+else
+  exec "$@"
+fi

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,18 @@
+import subprocess
+import os
+
+
+def run(beat, command):
+    image = 'docker.elastic.co/beats/%s:%s' % (beat.name, beat.version)
+
+    caps = ''
+    if beat.name == 'packetbeat':
+        caps = '--cap-add net_admin --cap-add net_raw'
+
+    if beat.name == 'heartbeat':
+        caps = '--cap-add net_raw'
+
+    cli = 'docker run %s --rm --interactive %s %s' % (caps, image, command)
+    result = subprocess.run(cli, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+    result.stdout = result.stdout.rstrip()
+    return result

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -1,0 +1,13 @@
+from .fixtures import beat
+from .helpers import run
+
+
+def test_entrypoint_args(Command, beat):
+    cmd = run(beat, "-c %s -configtest" % beat.config_file.path)
+    assert cmd.returncode == 0
+
+
+def test_entrypoint_command(Command, beat):
+    cmd = run(beat, "echo Hello World!")
+    assert cmd.returncode == 0
+    assert cmd.stdout == b'Hello World!'


### PR DESCRIPTION
This change takes benefit of Dockerfile `ENTRYPOINT`, so users can pass
arguments to beats without rewriting the full command, like:

docker run docker.elastic.co/beats/metricbeat:6.0.0 -e -v -d '*'

Does this PR include tests?

`beats-docker` is developed under a test-driven
workflow, so please refrain from submitting patches without test
coverage. If you are not familiar with testing in Python, please
raise an issue instead.

Closes #6 

**Note**: I opened this PR for 6.x branch only, as it breaks backwards compatibility, I think it doesn't make sense to do the same change in 5.X, does it?