### PR TITLE
Don't download dashboards zip file, it's been moved into package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,6 @@ $(BEATS):
 	  -D beat=$@ \
 	  -D version=$(ELASTIC_VERSION) \
 	  -D url=$(DOWNLOAD_URL_ROOT)/$@/$@-$(ELASTIC_VERSION)-linux-x86_64.tar.gz \
-	  -D dashboards_url=$(DOWNLOAD_URL_ROOT)/beats-dashboards/beats-dashboards-$(ELASTIC_VERSION).zip \
           templates/Dockerfile.j2 > build/$@/Dockerfile
 	docker build --tag=$(REGISTRY)/beats/$@:$(VERSION_TAG) build/$@
 

--- a/templates/Dockerfile.j2
+++ b/templates/Dockerfile.j2
@@ -12,7 +12,6 @@ RUN curl -Lso - {{ url }} | \
       tar zxf - -C /tmp && \
     mv /tmp/{{ beat }}-{{ version }}-linux-x86_64 {{ beat_home }}
 
-RUN curl -Lso {{ beat_home }}/beats-dashboards-{{ version }}.zip {{ dashboards_url }}
 
 ENV ELASTIC_CONTAINER true
 ENV PATH={{ beat_home }}:$PATH

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -58,6 +58,8 @@ services:
     depends_on:
       elasticsearch:
         condition: service_healthy
+    healthcheck:
+      test: ['CMD', 'curl', '-f', '-u', 'docker:changeme', 'http://localhost:5601']
 
   import_dashboards:
       image: {{ registry }}/beats/metricbeat:{{ version }}
@@ -66,14 +68,15 @@ services:
          - beats
       # Using -beat "" causes it to install all dashboards in the zip and not just the metricbeat ones.
       command: >-
-        /usr/share/metricbeat/scripts/import_dashboards
-          -beat ""
-          -file /usr/share/metricbeat/beats-dashboards-{{ version }}.zip
-          -es http://elasticsearch:9200
-          -user elastic
-          -pass changeme
+        /usr/share/metricbeat/metricbeat setup --dashboards
+        -E setup.kibana.host=kibana:5601
+        -E setup.kibana.username=docker
+        -E setup.kibana.password=changeme
+
       depends_on:
         elasticsearch:
+          condition: service_healthy
+        kibana:
           condition: service_healthy
 
   set_default_index_pattern:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -10,16 +10,16 @@ except KeyError:
 
 class Beat:
     def __init__(self, name, process, home_dir, data_dir, config_dir, log_dir,
-                 binary_file, config_file, dashboard_file, capabilities):
+                 kibana_dir, binary_file, config_file, capabilities):
         self.name = name
         self.process = process
         self.home_dir = home_dir
         self.data_dir = data_dir
         self.config_dir = config_dir
         self.log_dir = log_dir
+        self.kibana_dir = kibana_dir
         self.binary_file = binary_file
         self.config_file = config_file
-        self.dashboard_file = dashboard_file
         self.version = version
         self.capabilities = capabilities
 
@@ -47,8 +47,8 @@ def beat(Process, File, TestinfraBackend, Command):
         data_dir=File(os.path.join(beat_home, 'data')),
         config_dir=File(beat_home),
         log_dir=File(os.path.join(beat_home, 'logs')),
+        kibana_dir=File(os.path.join(beat_home, 'kibana')),
         config_file=File(os.path.join(beat_home, '%s.yml' % beat_name)),
         binary_file=binary_file,
-        dashboard_file=File(os.path.join(beat_home, 'beats-dashboards-%s.zip' % version)),
         capabilities=capabilities,
     )

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -56,19 +56,13 @@ def test_data_dir_permissions(beat):
     assert beat.data_dir.mode == 0o0770
 
 
+def test_kibana_dir_permissions(beat):
+    assert beat.kibana_dir.user == 'root'
+    assert beat.kibana_dir.group == beat.name
+    assert beat.kibana_dir.mode == 0o0750
+
+
 def test_log_dir_permissions(beat):
     assert beat.log_dir.user == 'root'
     assert beat.log_dir.group == beat.name
     assert beat.log_dir.mode == 0o0770
-
-
-def test_dashboard_archive_is_present(beat):
-    assert beat.dashboard_file.exists
-
-
-def test_dashboard_archive_is_a_reasonable_size(beat):
-    assert beat.dashboard_file.size > (100 * 1024)
-
-
-def test_dashboard_archive_is_a_zip_file(beat):
-    assert beat.dashboard_file.content[0:4] == b'PK\x03\x04'


### PR DESCRIPTION
Kibana dashboards are now included in beats packages, so there is no need to download a separate zip file. See https://github.com/elastic/beats/pull/4675 for details.

This PR address this change by using the new dashboards setup mode, and ensuring `kibana` folder is present in resulting containers.