### PR TITLE
Update filebeat and metricbeat settings to use dynamic modules

### DIFF
--- a/build/filebeat/config/filebeat.yml
+++ b/build/filebeat/config/filebeat.yml
@@ -1,7 +1,10 @@
-filebeat.prospectors:
-- input_type: log
-  paths:
-    - /mnt/log/*.log
+filebeat.config:
+  prospectors:
+    path: ${path.config}/prospectors.d/*.yml
+    reload.enabled: false
+  modules:
+    path: ${path.config}/modules.d/*.yml
+    reload.enabled: false
 
 processors:
 - add_cloud_metadata:

--- a/build/filebeat/config/prospectors.d/default.yml
+++ b/build/filebeat/config/prospectors.d/default.yml
@@ -1,0 +1,3 @@
+- input_type: log
+  paths:
+    - /mnt/log/*.log

--- a/build/metricbeat/config/metricbeat.yml
+++ b/build/metricbeat/config/metricbeat.yml
@@ -1,26 +1,6 @@
-metricbeat.modules:
-- module: system
-  metricsets:
-    - cpu
-    - load
-    - memory
-    - network
-    - process
-  enabled: true
-  period: 10s
-  processes: ['.*']
-
-# In order to capture short lived connections, use a shorter period for system/sockets.
-- module: system
-  metricsets: [socket]
-  period: 500ms
-  socket.reverse_lookup.enabled: true
-
-- module: system
-  period: 60s
-  metricsets: [filesystem, fsstat]
-  processors:
-    - drop_event.when.regexp.mount_point: '^(/hostfs)?/(sys|cgroup|proc|dev|etc|host|var/lib/docker)($|/)'
+metricbeat.config.modules:
+  path: ${path.config}/modules.d/*.yml
+  reload.enabled: false
 
 processors:
 - add_cloud_metadata:

--- a/templates/Dockerfile.j2
+++ b/templates/Dockerfile.j2
@@ -1,7 +1,6 @@
 # This Dockerfile was generated from templates/Dockerfile.j2
 {% set beat_home = '/usr/share/%s' % beat -%}
 {% set binary_file = '%s/%s' % (beat_home, beat) -%}
-{% set config_file = '%s/%s.yml' % (beat_home, beat) -%}
 
 FROM centos:7
 MAINTAINER Elastic Docker Team <docker@elastic.co>
@@ -17,7 +16,7 @@ RUN curl -Lso {{ beat_home }}/beats-dashboards-{{ version }}.zip {{ dashboards_u
 ENV ELASTIC_CONTAINER true
 ENV PATH={{ beat_home }}:$PATH
 
-COPY config/{{ beat }}.yml {{ config_file }}
+COPY config {{ beat_home }}
 
 # Provide a non-root user.
 RUN groupadd --gid 1000 {{ beat }} && \
@@ -29,6 +28,9 @@ RUN mkdir data logs && \
     find {{ beat_home }} -type d -exec chmod 0750 {} \; && \
     find {{ beat_home }} -type f -exec chmod 0640 {} \; && \
     chmod 0750 {{ binary_file }} scripts/* && \
+    {%- if beat == 'filebeat' or beat == 'metricbeat' %}
+    chmod 0770 modules.d && \
+    {% endif %}
     chmod 0770 data logs
 
 {%- if beat == 'packetbeat' %}

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1,0 +1,23 @@
+from .fixtures import beat
+import os
+
+# Beats supporting modules command:
+MODULES_BEATS = ('filebeat', 'metricbeat')
+
+
+def test_list_modules(Command, beat):
+    if beat.name in MODULES_BEATS:
+        cmd = Command.run('%s modules list' % beat.name)
+
+        assert cmd.rc == 0
+        assert 'Enabled' in cmd.stdout
+        assert 'Disabled' in cmd.stdout
+        assert 'system' in cmd.stdout
+
+
+def test_enable_module(Command, beat):
+    if beat.name in MODULES_BEATS:
+        cmd = Command.run('%s modules enable nginx' % beat.name)
+
+        assert cmd.rc == 0
+        assert cmd.stdout == 'Enabled nginx\n'


### PR DESCRIPTION
...and also prospectors in the case of filebeat.

Latest changes in both beats provide a `modules` command, to easily
enable & disable modules from a modules.d folder.

This should also benefit kubernetes users, as they will be able to mount
a ConfigMap under `modules.d` or `prospectors.d` without changing main
config file.

Of course one file settings should still work as always, it can be
overriden with `docker -v'