### PR TITLE
Fix README links towards the *beats Docker documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,19 @@
 This repository contains the official [Beats][beats] Docker images from
 [Elastic][elastic].
 
-Documentation can be found on the [Elastic website][docs]
+Documentation can be found on the [Elastic website][elastic]:
+
+* [filebeat][filebeat]
+* [heartbeat][heartbeat]
+* [metricbeat][metricbeat]
+* [packetbeat][packetbeat]
 
 [beats]: https://www.elastic.co/products/beats
 [elastic]: https://www.elastic.co/
-[docs]: https://www.elastic.co/guide/en/logstash/current/docker.html
+[filebeat]: https://www.elastic.co/guide/en/beats/filebeat/current/running-on-docker.html
+[heartbeat]: https://www.elastic.co/guide/en/beats/heartbeat/current/running-on-docker.html
+[metricbeat]: https://www.elastic.co/guide/en/beats/metricbeat/current/running-on-docker.html
+[packetbeat]: https://www.elastic.co/guide/en/beats/packetbeat/current/running-on-docker.html
 
 ## Requirements
 A full build and test requires:


### PR DESCRIPTION
The current README has links towards the Logstash documentation instead.

Without prior knowledge of the naming conventions, it's difficult to find the exact repository and names/tags to pull the images from.