### PR TITLE
Use system user instead of regular user

### DIFF
--- a/templates/Dockerfile.j2
+++ b/templates/Dockerfile.j2
@@ -20,9 +20,9 @@ COPY config {{ beat_home }}
 # Add entrypoint wrapper script
 ADD docker-entrypoint /usr/local/bin
 
-# Provide a non-root user.
-RUN groupadd --gid 1000 {{ beat }} && \
-    useradd -M --uid 1000 --gid 1000 --home {{ beat_home }} {{ beat }}
+# Provide a custom system user.
+RUN groupadd --system --gid 900 {{ beat }} && \
+    useradd --system -M --uid 900 --gid 900 --home {{ beat_home }} {{ beat }}
 
 WORKDIR {{ beat_home }}
 RUN mkdir data logs && \


### PR DESCRIPTION
CentOs (and many other distros) reserve uid < 1000 for system users.

Does this PR include tests?

Does not apply. This is to prevent uid collisions with host os.