### PR TITLE
Add volume stanza to document where filebeat expects write accesss

### DIFF
--- a/templates/Dockerfile.j2
+++ b/templates/Dockerfile.j2
@@ -58,5 +58,6 @@ LABEL org.label-schema.schema-version="1.0" \
   license="Elastic License"
 {% endif -%}
 
+VOLUME ["{{ beat_home }}/data", "{{ beat_home }}/logs"]
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]
 CMD ["-e"]

--- a/templates/Dockerfile.j2
+++ b/templates/Dockerfile.j2
@@ -58,6 +58,6 @@ LABEL org.label-schema.schema-version="1.0" \
   license="Elastic License"
 {% endif -%}
 
-VOLUME ["{{ beat_home }}/data", "{{ beat_home }}/logs"]
+VOLUME ["{{ beat_home }}/data", "{{ beat_home }}/logs", "/mnt/log/"]
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]
 CMD ["-e"]

--- a/tests/test_volumes.py
+++ b/tests/test_volumes.py
@@ -4,3 +4,4 @@ from .fixtures import beat
 def test_volumes(beat):
     volumes = beat.docker_metadata['Config']['Volumes']
     assert len(volumes) > 0
+    assert "/mnt/log/" in volumes

--- a/tests/test_volumes.py
+++ b/tests/test_volumes.py
@@ -1,0 +1,6 @@
+from .fixtures import beat
+
+
+def test_volumes(beat):
+    volumes = beat.docker_metadata['Config']['Volumes']
+    assert len(volumes) > 0


### PR DESCRIPTION
Does this PR include tests? Yes

Hi, I'm Ted Hahn and I'm working on the Kubernetes team at Nordstrom. We're trying to implement Pod Security Policies (PSP) org-wide, and your container image is used by some of our teams. 

I'm trying to remedy the following attributes: 
- [ ] Writes to rootfs
- [ ] No Volumes listed

Writes to / are not permitted to prevent attackers from overwriting binaries or modules that might be dynamically loaded or otherwise executed. This is the equivalent of running the docker image with the `--read-only` flag.

Explicitly listing writable Volumes serves as documentation for which mount points are used by the container. Docker will default to mounting a temporary volume at these locations if no other mount is given (enabling the container to still be run even with the `--read-only` flag)